### PR TITLE
fix: arrayIterator + null string warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "doc": "phpdoc project:run --sourcecode --cache-folder=/tmp/phpdoc-cache/ --force -v",
-    "test": "php ./bin/phpunit --no-coverage --no-logging --testdox",
+    "test": "php ./bin/phpunit --no-coverage --no-logging --testdox --verbose",
     "test-coverage": "php ./bin/phpunit --debug",
     "metrics": "php ./bin/phpmetrics --config=.phpmetrics.yml src/",
     "dedup": "php ./bin/phpcpd --exclude=src/MarkdownExtendedDev/ src/",

--- a/src/MarkdownExtended/Util/ContentCollection.php
+++ b/src/MarkdownExtended/Util/ContentCollection.php
@@ -38,6 +38,7 @@ class ContentCollection extends \ArrayIterator
      *
      * @throws \MarkdownExtended\Exception\UnexpectedValueException it the argument does not implement `\MarkdownExtended\API\ContentInterface`
      */
+    #[\ReturnTypeWillChange]
     public function append($content)
     {
         if (!is_object($content) || !Kernel::valid($content, Kernel::TYPE_CONTENT)) {
@@ -61,6 +62,7 @@ class ContentCollection extends \ArrayIterator
      *
      * @throws \MarkdownExtended\Exception\UnexpectedValueException it the argument does not implement `\MarkdownExtended\API\ContentInterface`
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($index, $content)
     {
         if (!is_object($content) || !Kernel::valid($content, Kernel::TYPE_CONTENT)) {

--- a/src/MarkdownExtended/Util/Helper.php
+++ b/src/MarkdownExtended/Util/Helper.php
@@ -42,7 +42,7 @@ class Helper
      */
     public static function fillPlaceholders($text, $replacement)
     {
-        return str_replace('%%', $replacement, $text);
+        return !is_null($text) ? str_replace('%%', $replacement, $text) : $text;
     }
 
     /**


### PR DESCRIPTION
* arrayIterator warning for the \MarkdownExtended\Util\ContentCollection object in PHP 8
* add a validation on an eventually null string